### PR TITLE
Fixed Navbar Opacity issue

### DIFF
--- a/frontend/src/components/Navigation/NavigationBar.js
+++ b/frontend/src/components/Navigation/NavigationBar.js
@@ -87,7 +87,8 @@ const styles = {
   navBox: {
     width: '100%',
     position: 'fixed',
-    bottom: '30px'
+    bottom: '30px',
+    zIndex: '10'
   },
   bottomNav: {
     width: '100%',


### PR DESCRIPTION
The navBox style needed a zIndex property > 0.

Set zIndex at '10'